### PR TITLE
Centralize loading-screen timing config

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1,8 +1,8 @@
+// v17
 // ───────────────────────────────────────────────────────────────────────────────
 // A) FIREBASE IMPORTS (Modular v11.8.1)
 // ───────────────────────────────────────────────────────────────────────────────
-import { initializeApp } from "https://www.gstatic.com/firebasejs/11.8.1/firebase-app.js";
-import { getAnalytics } from "https://www.gstatic.com/firebasejs/11.8.1/firebase-analytics.js";
+import { initializeApp, getApps } from "https://www.gstatic.com/firebasejs/11.8.1/firebase-app.js";
 import {
     getAuth,
     signInWithEmailAndPassword,
@@ -21,6 +21,122 @@ import {
     connectFirestoreEmulator
 } from "https://www.gstatic.com/firebasejs/11.8.1/firebase-firestore.js";
 
+console.log("\uD83D\uDD25 app.js has loaded!");
+// ─────────────────────────────────────────────────────────────────────────────
+// CONFIGURATION: Welcome Screen / Loading Screen Editor
+// ─────────────────────────────────────────────────────────────────────────────
+
+// 1) Device Detection (no need to change)
+const IS_MOBILE = window.matchMedia("(max-width: 768px)").matches;
+
+// ─────────── Desktop Values ───────────
+const DESKTOP_WELCOME_BLACK_DURATION_MS        = 1000;   // Black background static time (desktop)
+const DESKTOP_TEXT_APPEAR_DELAY_MS             = 0;      // Delay before text appears (desktop)
+const DESKTOP_TEXT_INITIAL_FONT_SIZE_PX        = 32;     // Starting font size of text (desktop)
+const DESKTOP_TEXT_FINAL_FONT_SIZE_PX          = 48;     // Final font size of text (desktop)
+const DESKTOP_TEXT_INITIAL_COLOR               = "#FFFFFF"; // Starting color of text (desktop)
+const DESKTOP_TEXT_FINAL_COLOR                 = "#000000"; // Ending color of text (desktop)
+const DESKTOP_TEXT_SCALE_DURATION_MS           = 6000;   // Duration of text scale/color transition (desktop)
+const DESKTOP_TEXT_SCALE_EASING                = "ease-in-out"; // Easing for text scale/color (desktop)
+
+const DESKTOP_BACKGROUND_FADE_DURATION_MS      = 6000;   // Duration for black overlay fade (desktop)
+const DESKTOP_BACKGROUND_FADE_EASING           = "ease-in-out"; // Easing for background fade (desktop)
+
+const DESKTOP_TEXT_FADE_DELAY_BEFORE_BG_MS     = 0;      // Offset (ms) when text starts relative to bg fade
+const DESKTOP_TEXT_STAY_DURATION_MS            = 0;      // Time (ms) to hold text at final state (desktop)
+
+const DESKTOP_STARTUP_SCREEN_SELECTOR          = "#startup-screen"; // CSS selector for overlay div
+const DESKTOP_STARTUP_TEXT_SELECTOR            = "#startup-text";   // CSS selector for welcome text
+
+// ─────────── Mobile Values ───────────
+const MOBILE_WELCOME_BLACK_DURATION_MS         = 250;    // Black background static time (mobile)
+const MOBILE_TEXT_APPEAR_DELAY_MS              = 0;      // Delay before text appears (mobile)
+const MOBILE_TEXT_INITIAL_FONT_SIZE_PX         = 24;     // Starting font size of text (mobile)
+const MOBILE_TEXT_FINAL_FONT_SIZE_PX           = 36;     // Final font size of text (mobile)
+const MOBILE_TEXT_INITIAL_COLOR                = "#FFFFFF"; // Starting color of text (mobile)
+const MOBILE_TEXT_FINAL_COLOR                  = "#000000"; // Ending color of text (mobile)
+const MOBILE_TEXT_SCALE_DURATION_MS            = 3000;   // Duration of text scale/color transition (mobile)
+const MOBILE_TEXT_SCALE_EASING                 = "ease-in-out"; // Easing for text scale/color (mobile)
+
+const MOBILE_BACKGROUND_FADE_DURATION_MS       = 3000;   // Duration for black overlay fade (mobile)
+const MOBILE_BACKGROUND_FADE_EASING            = "ease-in-out"; // Easing for background fade (mobile)
+
+const MOBILE_TEXT_FADE_DELAY_BEFORE_BG_MS      = 0;      // Offset (ms) when text starts relative to bg fade
+const MOBILE_TEXT_STAY_DURATION_MS             = 0;      // Time (ms) to hold text at final state (mobile)
+
+const MOBILE_STARTUP_SCREEN_SELECTOR           = "#startup-screen"; // CSS selector for overlay div
+const MOBILE_STARTUP_TEXT_SELECTOR             = "#startup-text";   // CSS selector for welcome text
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SELECTED CONFIG VARIABLES (DO NOT EDIT BELOW)
+// ─────────────────────────────────────────────────────────────────────────────
+const WELCOME_BLACK_DURATION_MS     = IS_MOBILE
+  ? MOBILE_WELCOME_BLACK_DURATION_MS
+  : DESKTOP_WELCOME_BLACK_DURATION_MS;
+
+const TEXT_APPEAR_DELAY_MS          = IS_MOBILE
+  ? MOBILE_TEXT_APPEAR_DELAY_MS
+  : DESKTOP_TEXT_APPEAR_DELAY_MS;
+
+const TEXT_INITIAL_FONT_SIZE_PX     = IS_MOBILE
+  ? MOBILE_TEXT_INITIAL_FONT_SIZE_PX
+  : DESKTOP_TEXT_INITIAL_FONT_SIZE_PX;
+
+const TEXT_FINAL_FONT_SIZE_PX       = IS_MOBILE
+  ? MOBILE_TEXT_FINAL_FONT_SIZE_PX
+  : DESKTOP_TEXT_FINAL_FONT_SIZE_PX;
+
+const TEXT_INITIAL_COLOR            = IS_MOBILE
+  ? MOBILE_TEXT_INITIAL_COLOR
+  : DESKTOP_TEXT_INITIAL_COLOR;
+
+const TEXT_FINAL_COLOR              = IS_MOBILE
+  ? MOBILE_TEXT_FINAL_COLOR
+  : DESKTOP_TEXT_FINAL_COLOR;
+
+const TEXT_SCALE_DURATION_MS        = IS_MOBILE
+  ? MOBILE_TEXT_SCALE_DURATION_MS
+  : DESKTOP_TEXT_SCALE_DURATION_MS;
+
+const TEXT_SCALE_EASING             = IS_MOBILE
+  ? MOBILE_TEXT_SCALE_EASING
+  : DESKTOP_TEXT_SCALE_EASING;
+
+const BACKGROUND_FADE_DURATION_MS   = IS_MOBILE
+  ? MOBILE_BACKGROUND_FADE_DURATION_MS
+  : DESKTOP_BACKGROUND_FADE_DURATION_MS;
+
+const BACKGROUND_FADE_EASING        = IS_MOBILE
+  ? MOBILE_BACKGROUND_FADE_EASING
+  : DESKTOP_BACKGROUND_FADE_EASING;
+
+const TEXT_FADE_DELAY_BEFORE_BG_MS  = IS_MOBILE
+  ? MOBILE_TEXT_FADE_DELAY_BEFORE_BG_MS
+  : DESKTOP_TEXT_FADE_DELAY_BEFORE_BG_MS;
+
+const TEXT_STAY_DURATION_MS         = IS_MOBILE
+  ? MOBILE_TEXT_STAY_DURATION_MS
+  : DESKTOP_TEXT_STAY_DURATION_MS;
+
+const STARTUP_SCREEN_SELECTOR       = IS_MOBILE
+  ? MOBILE_STARTUP_SCREEN_SELECTOR
+  : DESKTOP_STARTUP_SCREEN_SELECTOR;
+
+const STARTUP_TEXT_SELECTOR         = IS_MOBILE
+  ? MOBILE_STARTUP_TEXT_SELECTOR
+  : DESKTOP_STARTUP_TEXT_SELECTOR;
+
+// Optional: Skip animation entirely (debug only)
+const SKIP_WELCOME_ANIMATION = false;
+
+const SIGNUP_SUCCESS_DELAY_MS    = 1200;   // Pause after account creation before continuing
+const WELCOME_BANNER_DURATION_MS = 2500;   // How long the post-login banner stays visible
+const WELCOME_BANNER_FADE_MS     = 300;    // Fade duration for the banner
+const LOADER_SPINNER_DURATION_MS = 300;    // Length of the loading spinner
+
+const fadeDurationSeconds = (BACKGROUND_FADE_DURATION_MS / 1000) + "s";
+document.documentElement.style.setProperty("--welcome-fade-duration", fadeDurationSeconds);
+
 // ───────────────────────────────────────────────────────────────────────────────
 // B) FIREBASE CONFIGURATION
 // Copy/paste this from your Firebase console → Project Settings (Web App)
@@ -29,7 +145,7 @@ const firebaseConfig = {
     apiKey: "AIzaSyDwfQcrwMCbbX6CA-_1UgelCNfVKCVTQ0A",
     authDomain: "linkerapp-9dd4d.firebaseapp.com",
     projectId: "linkerapp-9dd4d",
-    storageBucket: "linkerapp-9dd4d.firebasestorage.app",
+    storageBucket: "linkerapp-9dd4d.appspot.com",
     messagingSenderId: "1098052666181",
     appId: "1:1098052666181:web:526d045f1c8f44f59fb42c",
     measurementId: "G-LBV1P494PR"
@@ -37,7 +153,6 @@ const firebaseConfig = {
 
 // Initialize Firebase App / Analytics / Auth / Firestore
 const app = initializeApp(firebaseConfig);
-const analytics = getAnalytics(app);
 const auth = getAuth(app);
 const db = getFirestore(app);
 
@@ -69,13 +184,15 @@ const STORAGE_KEY_LINKTREE = "linkerLinktreeData";
 let linkRows = [];
 // Will hold the base64‐DataURL for the uploaded profile pic
 let profilePicDataURL = "";
+// Optional background image for the card
+let cardImageDataURL = "";
 
 // ───────────────────────────────────────────────────────────────────────────────
 // E) UI ELEMENT REFERENCES
 // ───────────────────────────────────────────────────────────────────────────────
 // (These IDs must match exactly what’s in index.html—don’t rename!)
-const startupScreen = document.getElementById("startup-screen");
-const startupText = document.getElementById("startup-text");
+const startupScreen = document.querySelector(STARTUP_SCREEN_SELECTOR);
+const startupText = document.querySelector(STARTUP_TEXT_SELECTOR);
 const resetBtn = document.getElementById("reset-btn");
 
 const loginScreen = document.getElementById("login-screen");
@@ -123,6 +240,12 @@ const formUsernameInput = document.getElementById("username");
 const errorUsername = document.getElementById("error-username");
 const formTaglineInput = document.getElementById("tagline");
 const formTaglineCount = document.getElementById("tagline-count");
+const gradientStartInput = document.getElementById("gradient-start");
+const gradientEndInput = document.getElementById("gradient-end");
+const cardColorInput = document.getElementById("card-color");
+const cardTextColorInput = document.getElementById("card-text-color");
+const cardImageInput = document.getElementById("card-image");
+const cardImageClearBtn = document.getElementById("remove-card-image");
 const linksWrapper = document.getElementById("links-wrapper");
 const addLinkBtn = document.getElementById("add-link-btn");
 const errorLinks = document.getElementById("error-links");
@@ -131,6 +254,7 @@ const generateBtn = document.getElementById("generate-btn");
 const loaderScreen = document.getElementById("loader-screen");
 
 const linktreeScreen = document.getElementById("linktree-screen");
+const outputCard = document.getElementById("output-card");
 const outputProfilePic = document.getElementById("output-profile-pic");
 const displayUsername = document.getElementById("display-username");
 const outputTagline = document.getElementById("output-tagline");
@@ -142,7 +266,7 @@ const downloadBtn = document.getElementById("download-btn");
 // F) UTILITY HELPERS
 // ───────────────────────────────────────────────────────────────────────────────
 function delay(ms) {
-    return new Promise((resolve) => setTimeout(resolve, ms));
+    return new window.Promise((resolve) => setTimeout(resolve, ms));
 }
 
 function hideAllScreens() {
@@ -186,28 +310,69 @@ function downloadBlob(filename, blob) {
     URL.revokeObjectURL(url);
 }
 
+function escapeHTML(str) {
+    return str
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;")
+        .replace(/'/g, "&#39;");
+}
+
 // ───────────────────────────────────────────────────────────────────────────────
-// G) ON PAGE LOAD: Animate the “Welcome to Linker” fade (500ms delay → 1.5s fade)
+// G) ON PAGE LOAD: Animate the “Welcome to Linker” fade (1s delay → 6s fade)
 //                 Then FORCE sign-out any existing user, then call initApp()
 // ───────────────────────────────────────────────────────────────────────────────
-window.addEventListener("DOMContentLoaded", () => {
-    // Start fade after 500ms
-    setTimeout(() => {
-        startupScreen.classList.add("fade-bg-out");
-        startupText.classList.add("slide-text-up");
+window.addEventListener("load", () => {
+    console.log("Welcome screen loaded");
 
-        // After 1.5s, remove overlay and sign out
-        setTimeout(async () => {
-            startupScreen.style.display = "none";
-            try {
-                await signOut(auth);
-            } catch (e) {
-                console.warn("Sign-out on load failed (maybe not signed in):", e);
+    if (SKIP_WELCOME_ANIMATION) {
+        startupScreen.remove();
+        signOut(auth).finally(() => initApp());
+        return;
+    }
+
+    // Apply initial text styles and force layout so transition starts from these values
+    if (startupText) {
+        startupText.style.fontSize = `${TEXT_INITIAL_FONT_SIZE_PX}px`;
+        startupText.style.color = TEXT_INITIAL_COLOR;
+        void startupText.offsetWidth; // force reflow
+    }
+
+    // Wait for the black screen duration
+    setTimeout(() => {
+        console.log("Starting text animation");
+
+        // Optionally delay text appearance relative to background fade
+        setTimeout(() => {
+            if (startupText) {
+                startupText.style.fontSize = `${TEXT_FINAL_FONT_SIZE_PX}px`;
+                startupText.style.color = TEXT_FINAL_COLOR;
             }
-            // Now that we’re signed out, we can initialize the rest of the app
+        }, TEXT_APPEAR_DELAY_MS);
+
+        // Start background fade
+        startupScreen.classList.add("reveal");
+        console.log("Background fade-out started");
+
+        // Wait for fade duration before removing overlay
+        setTimeout(async () => {
+            console.log("Fade complete, removing overlay");
+            startupScreen.remove();
+
+            console.log("Signing out");
+            if (getApps().length) {
+                try {
+                    await signOut(auth);
+                } catch (err) {
+                    console.warn(err);
+                }
+            }
+
+            console.log("Initializing app");
             initApp();
-        }, 1500);
-    }, 500);
+        }, BACKGROUND_FADE_DURATION_MS);
+    }, WELCOME_BLACK_DURATION_MS);
 });
 
 // ───────────────────────────────────────────────────────────────────────────────
@@ -412,7 +577,7 @@ signupSubmit.addEventListener("click", async () => {
         setTimeout(() => {
             hideAllScreens();
             startAppFlow(email);
-        }, 1200);
+        }, SIGNUP_SUCCESS_DELAY_MS);
     } catch (err) {
         console.error("Error creating user:", err);
         signupCodeError.textContent = "Signup failed—email may already be in use.";
@@ -444,16 +609,25 @@ async function startAppFlow(currentEmail) {
 
     // Fade banner in/out:
     welcomeText.classList.remove("opacity-0");    // show it
-    await delay(2500);                            // keep it visible 2.5s
+    await delay(WELCOME_BANNER_DURATION_MS);                            // keep it visible 2.5s
     welcomeText.classList.add("opacity-0");       // fade it out
-    await delay(300);                             // wait 0.3s for fade to complete
+    await delay(WELCOME_BANNER_FADE_MS);                             // wait 0.3s for fade to complete
+    // Hide the welcome overlay before proceeding
+    welcomeScreen.classList.add("hidden");
+    welcomeScreen.classList.remove("flex");
 
     // Now either show loader + output or show builder form
-    const savedData = JSON.parse(localStorage.getItem(STORAGE_KEY_LINKTREE) || "null");
+    let savedData = null;
+    try {
+        savedData = JSON.parse(localStorage.getItem(STORAGE_KEY_LINKTREE) || "null");
+    } catch (err) {
+        console.warn("Failed to parse saved Linktree data, clearing", err);
+        localStorage.removeItem(STORAGE_KEY_LINKTREE);
+    }
     if (savedData) {
         loaderScreen.classList.remove("hidden");
         loaderScreen.classList.add("flex");
-        await delay(300);                           // spinner for 0.3s
+        await delay(LOADER_SPINNER_DURATION_MS);                           // spinner for 0.3s
         loaderScreen.classList.add("hidden");
         loaderScreen.classList.remove("flex");
         renderOutput(savedData);
@@ -474,6 +648,8 @@ function showBuilderForm(prefillData = null) {
     linksWrapper.innerHTML = "";
     linkRows = [];
     profilePicDataURL = "";
+    cardImageDataURL = "";
+    cardImageInput.value = "";
 
     // Hide errors
     errorProfilePic.classList.add("hidden");
@@ -488,12 +664,25 @@ function showBuilderForm(prefillData = null) {
         formUsernameInput.value = prefillData.username || "";
         formTaglineInput.value = prefillData.tagline || "";
         formTaglineCount.textContent = `${prefillData.tagline?.length || 0}/100`;
+        gradientStartInput.value = prefillData.gradientStart || "#a7f3d0";
+        gradientEndInput.value = prefillData.gradientEnd || "#6ee7b7";
+        cardColorInput.value = prefillData.cardColor || "#ffffff";
+        cardTextColorInput.value = prefillData.cardTextColor || "#111827";
+        if (prefillData.cardImage) {
+            cardImageDataURL = prefillData.cardImage;
+        }
+        cardImageInput.value = "";
 
         (prefillData.links || []).forEach((link) => addLinkRow(link));
     } else {
         formUsernameInput.value = "";
         formTaglineInput.value = "";
         formTaglineCount.textContent = "0/100";
+        gradientStartInput.value = "#a7f3d0";
+        gradientEndInput.value = "#6ee7b7";
+        cardColorInput.value = "#ffffff";
+        cardTextColorInput.value = "#111827";
+        cardImageInput.value = "";
         addLinkRow();
     }
     updateGenerateButtonState();
@@ -523,7 +712,22 @@ function addLinkRow(prefill = null) {
     iconSelect.id = `link-icon-${rowIndex}`;
     iconSelect.className =
         "w-full px-3 py-2 rounded-md bg-gray-700 text-gray-100 focus:outline-none focus:ring-2 focus:ring-emerald-400";
-    ["fa-globe", "fa-instagram", "fa-github", "fa-link", "fa-camera", "fa-pinterest"].forEach((ic) => {
+    [
+        "fa-globe",
+        "fa-instagram",
+        "fa-github",
+        "fa-link",
+        "fa-camera",
+        "fa-pinterest",
+        "fa-twitter",
+        "fa-facebook",
+        "fa-youtube",
+        "fa-linkedin",
+        "fa-tiktok",
+        "fa-snapchat",
+        "fa-discord",
+        "fa-reddit",
+    ].forEach((ic) => {
         const opt = document.createElement("option");
         opt.value = ic;
         opt.textContent = ic.replace("fa-", "").charAt(0).toUpperCase() + ic.replace("fa-", "").slice(1);
@@ -550,7 +754,7 @@ function addLinkRow(prefill = null) {
     // 5) Delete button
     const deleteBtn = document.createElement("button");
     deleteBtn.type = "button";
-    deleteBtn.innerHTML = '<i class="fa fa-trash text-red-500"></i>';
+    deleteBtn.innerHTML = '<i class="fa fa-trash text-red-500" aria-hidden="true"></i>';
     deleteBtn.setAttribute("aria-label", "Remove this link");
     deleteBtn.className = "mt-2 focus:outline-none focus:ring-2 focus:ring-red-500 rounded-full";
     deleteBtn.addEventListener("click", () => {
@@ -566,7 +770,7 @@ function addLinkRow(prefill = null) {
     // 6) Move Up button
     const moveUpBtn = document.createElement("button");
     moveUpBtn.type = "button";
-    moveUpBtn.innerHTML = '<i class="fa fa-arrow-up"></i>';
+    moveUpBtn.innerHTML = '<i class="fa fa-arrow-up" aria-hidden="true"></i>';
     moveUpBtn.setAttribute("aria-label", "Move this link up");
     moveUpBtn.className =
         "ml-2 text-gray-300 hover:text-white focus:outline-none focus:ring-2 focus:ring-emerald-400 rounded";
@@ -581,7 +785,7 @@ function addLinkRow(prefill = null) {
     // 7) Move Down button
     const moveDownBtn = document.createElement("button");
     moveDownBtn.type = "button";
-    moveDownBtn.innerHTML = '<i class="fa fa-arrow-down"></i>';
+    moveDownBtn.innerHTML = '<i class="fa fa-arrow-down" aria-hidden="true"></i>';
     moveDownBtn.setAttribute("aria-label", "Move this link down");
     moveDownBtn.className =
         "ml-1 text-gray-300 hover:text-white focus:outline-none focus:ring-2 focus:ring-emerald-400 rounded";
@@ -694,6 +898,25 @@ profilePicFileInput.addEventListener("change", () => {
     updateGenerateButtonState();
 });
 
+// Card background image upload (optional)
+cardImageInput.addEventListener("change", () => {
+    const file = cardImageInput.files[0];
+    if (file && file.type.startsWith("image/")) {
+        const reader = new FileReader();
+        reader.onload = (e) => {
+            cardImageDataURL = e.target.result;
+        };
+        reader.readAsDataURL(file);
+    } else {
+        cardImageDataURL = "";
+    }
+});
+
+cardImageClearBtn.addEventListener("click", () => {
+    cardImageDataURL = "";
+    cardImageInput.value = "";
+});
+
 // Username validation on blur
 formUsernameInput.addEventListener("blur", () => {
     let val = formUsernameInput.value.trim();
@@ -755,17 +978,28 @@ generateBtn.addEventListener("click", async (e) => {
         profilePic: profilePicDataURL,
         username: formUsernameInput.value.trim(),
         tagline: formTaglineInput.value.trim(),
+        gradientStart: gradientStartInput.value,
+        gradientEnd: gradientEndInput.value,
+        cardColor: cardColorInput.value,
+        cardTextColor: cardTextColorInput.value,
+        cardImage: cardImageDataURL,
         links: linkRows.map((r) => ({
             label: r.labelInput.value.trim(),
             icon: r.iconSelect.value,
             url: r.urlInput.value.trim()
         }))
     };
-    localStorage.setItem(STORAGE_KEY_LINKTREE, JSON.stringify(data));
+    try {
+        localStorage.setItem(STORAGE_KEY_LINKTREE, JSON.stringify(data));
+    } catch (err) {
+        console.warn("LocalStorage quota exceeded, stripping images", err);
+        const tmp = { ...data, profilePic: "", cardImage: "" };
+        localStorage.setItem(STORAGE_KEY_LINKTREE, JSON.stringify(tmp));
+    }
 
     loaderScreen.classList.remove("hidden");
     loaderScreen.classList.add("flex");
-    await delay(300);
+    await delay(LOADER_SPINNER_DURATION_MS);
     loaderScreen.classList.add("hidden");
     loaderScreen.classList.remove("flex");
     renderOutput(data);
@@ -775,6 +1009,14 @@ generateBtn.addEventListener("click", async (e) => {
 // T) RENDER OUTPUT (in-app Linktree with Download + Back-to-Edit)                 //
 // ───────────────────────────────────────────────────────────────────────────────
 function renderOutput(data) {
+    document.body.style.background = `linear-gradient(to bottom right, ${data.gradientStart || "#a7f3d0"}, ${data.gradientEnd || "#6ee7b7"})`;
+    outputCard.style.backgroundColor = data.cardColor || "#ffffff";
+    if (data.cardImage) {
+        outputCard.style.backgroundImage = `url(${data.cardImage})`;
+        outputCard.style.backgroundSize = "cover";
+    } else {
+        outputCard.style.backgroundImage = "none";
+    }
     if (data.profilePic) {
         outputProfilePic.src = data.profilePic;
         outputProfilePic.classList.remove("hidden");
@@ -789,6 +1031,10 @@ function renderOutput(data) {
         outputTagline.classList.add("hidden");
     }
 
+    const textColor = data.cardTextColor || "#111827";
+    displayUsername.style.color = textColor;
+    outputTagline.style.color = textColor;
+
     displayUsername.textContent = data.username || "@yourhandle";
 
     linksContainer.innerHTML = "";
@@ -799,7 +1045,13 @@ function renderOutput(data) {
             btn.target = "_blank";
             btn.className =
                 "flex items-center justify-center bg-emerald-500 text-white py-3 rounded-lg hover:bg-emerald-600 transition focus:outline-none focus:ring-2 focus:ring-emerald-400";
-            btn.innerHTML = `<i class="fa ${link.icon} mr-2"></i><span>${link.label}</span>`;
+            const icon = document.createElement("i");
+            icon.className = `fa ${link.icon} mr-2`;
+            icon.setAttribute("aria-hidden", "true");
+            const span = document.createElement("span");
+            span.textContent = link.label;
+            btn.appendChild(icon);
+            btn.appendChild(span);
             linksContainer.appendChild(btn);
         }
     });
@@ -823,10 +1075,13 @@ downloadBtn.addEventListener("click", () => {
     if (!data || !data.links || data.links.length === 0) return;
 
     const safeUsername = data.username.replace("@", "") || "linker";
-    const safeTagline = data.tagline || "";
+    const safeTagline = escapeHTML(data.tagline || "");
     const safePic = data.profilePic || "";
-    const bgColorStart = "#a7f3d0"; // Tailwind green-200
-    const bgColorEnd = "#6ee7b7"; // Tailwind green-300
+    const bgColorStart = data.gradientStart || "#a7f3d0";
+    const bgColorEnd = data.gradientEnd || "#6ee7b7";
+    const cardColor = data.cardColor || "#ffffff";
+    const textColor = data.cardTextColor || "#111827";
+    const cardImage = data.cardImage || "";
 
     // Build minimal HTML
     const outputHtml = `<!DOCTYPE html>
@@ -834,7 +1089,7 @@ downloadBtn.addEventListener("click", () => {
 <head>
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<title>${data.username}’s Linktree</title>
+<title>${escapeHTML(data.username)}’s Linktree</title>
 <style>
   body {
     margin: 0;
@@ -848,7 +1103,8 @@ downloadBtn.addEventListener("click", () => {
     min-height: 100vh;
   }
   .card {
-    background-color: #ffffff;
+    background-color: ${cardColor};
+    ${cardImage ? `background-image: url('${cardImage}'); background-size: cover;` : ""}
     border-radius: 16px;
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
     padding: 32px;
@@ -866,16 +1122,17 @@ downloadBtn.addEventListener("click", () => {
   h1 {
     margin: 0 0 8px 0;
     font-size: 1.5rem;
-    color: #111827;
+    color: ${textColor};
   }
   p.tag {
     margin: 0 0 16px 0;
     font-size: 1rem;
-    color: #4b5563;
+    color: ${textColor};
   }
   .link-btn {
     display: block;
     width: 100%;
+    box-sizing: border-box;
     margin: 8px 0;
     padding: 12px 16px;
     background-color: #10b981; /* emerald-500 */
@@ -904,12 +1161,12 @@ downloadBtn.addEventListener("click", () => {
 <body>
   <div class="card">
     ${safePic ? `<img src="${safePic}" alt="Profile picture" class="profile" />` : ""}
-    <h1>${data.username}</h1>
+    <h1>${escapeHTML(data.username)}</h1>
     ${safeTagline ? `<p class="tag">${safeTagline}</p>` : ""}
     ${data.links
             .map(
                 (link) =>
-                    `<a href="${link.url}" target="_blank" class="link-btn"><i class="fa ${link.icon}"></i>${link.label}</a>`
+                    `<a href="${escapeHTML(link.url)}" target="_blank" class="link-btn"><i class="fa ${link.icon}" aria-hidden="true"></i>${escapeHTML(link.label)}</a>`
             )
             .join("\n    ")}
   </div>
@@ -920,19 +1177,6 @@ downloadBtn.addEventListener("click", () => {
     const filename = `${safeUsername}-linktree.html`;
     downloadBlob(filename, blob);
 });
-
-// ───────────────────────────────────────────────────────────────────────────────
-// V) “Skip to Output” (if user has saved Linktree in localStorage)               //
-// ───────────────────────────────────────────────────────────────────────────────
-function skipToOutput(data) {
-    loaderScreen.classList.remove("hidden");
-    loaderScreen.classList.add("flex");
-    setTimeout(() => {
-        loaderScreen.classList.add("hidden");
-        loaderScreen.classList.remove("flex");
-        renderOutput(data);
-    }, 300);
-}
 
 // ───────────────────────────────────────────────────────────────────────────────
 // W) RESET BUTTON: Clear localStorage + Sign Out + reload page                   //

--- a/public/index.html
+++ b/public/index.html
@@ -1,3 +1,4 @@
+<!-- v17 -->
 <!DOCTYPE html>
 <html lang="en" class="h-full">
 
@@ -11,11 +12,15 @@
 
     <!-- Font Awesome (for the link icons, trash, arrows, etc.) -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css"
-        integrity="sha512-papZHh3cY3VpsQa0bpo0uZtBi8gm38UH3rzZBZagh1SWlDwptG25pbLBO0e4XgbV4QYxRo/mOZxjwRF+dc+0Fg=="
+        integrity="sha512-iecdLmaskl7CVkqkXNQ/ZH/XLlvWZOJyj7Yy7tcenmpD1ypASozpmT/E0iPtmFIB46ZmdtAc9eNBvH0H/ZpiBw=="
         crossorigin="anonymous" referrerpolicy="no-referrer" />
 
     <style>
         /* ────────────────────────────────────────────────────── */
+        :root {
+            --welcome-fade-duration: 6s; /* Overwritten by JS */
+        }
+
         /*  Startup / Fade Animations:                          */
         /* ────────────────────────────────────────────────────── */
         /* Fullscreen black overlay: */
@@ -30,26 +35,26 @@
             align-items: center;
             justify-content: center;
             z-index: 50;
-            transition: background-color 1.5s ease;
+            overflow: hidden;
+            clip-path: inset(0 0 0 0);
+            transition: clip-path var(--welcome-fade-duration) ease;
         }
 
-        /* When we add “fade-bg-out”, transition to transparent: */
-        #startup-screen.fade-bg-out {
-            background-color: transparent;
+        /* When we add “reveal", uncover from the top down */
+        #startup-screen.reveal {
+            clip-path: inset(100% 0 0 0);
         }
 
         /* The “Welcome to Linker” text: */
         #startup-text {
             color: white;
             font-size: 2rem;
-            opacity: 1;
-            transition: transform 1.5s ease, opacity 1.5s ease;
+            transition: font-size var(--welcome-fade-duration) ease, color var(--welcome-fade-duration) ease;
         }
 
-        /* When “slide-text-up” is added, move it up and fade out: */
-        #startup-text.slide-text-up {
-            transform: translateY(-30px);
-            opacity: 0;
+        /* Scale up and switch to black during reveal */
+        #startup-text.reveal {
+            color: black;
         }
     </style>
 </head>
@@ -205,13 +210,11 @@
     <!-- H) WELCOME SCREEN (After Login, Before Builder)                               -->
     <!-- ─────────────────────────────────────────────────────────────────────────────── -->
     <div id="welcome-screen"
-        class="hidden flex-col items-center justify-center min-h-screen text-center space-y-4 px-4">
-        <div class="bg-white rounded-xl shadow-lg p-8 w-full max-w-md">
-            <h2 id="welcome-text"
-                class="text-2xl font-semibold text-gray-900 opacity-0 transition-opacity duration-500">
-                <!-- Filled dynamically -->
-            </h2>
-        </div>
+        class="hidden fixed inset-0 z-40 flex items-center justify-center bg-black bg-opacity-80 text-center px-4">
+        <h2 id="welcome-text"
+            class="text-2xl font-semibold text-white opacity-0 transition-opacity duration-500">
+            <!-- Filled dynamically -->
+        </h2>
     </div>
 
 
@@ -219,7 +222,7 @@
     <!-- I) BUILDER FORM SCREEN (Upload Picture / Handle / Tagline / Links)            -->
     <!-- ─────────────────────────────────────────────────────────────────────────────── -->
     <div id="form-screen" class="hidden flex-col items-center justify-start min-h-screen text-center pt-12 px-4">
-        <div class="w-full max-w-md space-y-6">
+        <div class="card-wrapper bg-white rounded-xl shadow-lg p-8 w-full max-w-md space-y-6">
             <h2 class="text-2xl font-semibold text-gray-900">Build Your Linktree</h2>
             <p class="text-gray-800">
                 Upload a profile picture, add your handle, tagline, and links below.
@@ -248,6 +251,31 @@
                 <textarea id="tagline" rows="2" placeholder="Tell people what you do (max 100 chars)" maxlength="100"
                     class="w-full px-4 py-2 rounded-md border border-gray-300 focus:outline-none focus:ring-2 focus:ring-emerald-400"></textarea>
                 <p id="tagline-count" class="text-gray-600 text-sm">0/100</p>
+            </div>
+
+            <!-- Theme Customization -->
+            <div class="flex flex-col items-start">
+                <label for="gradient-start" class="font-medium text-gray-700 mb-1">Background Gradient Start</label>
+                <input id="gradient-start" type="color" value="#a7f3d0" class="w-full h-10" />
+            </div>
+            <div class="flex flex-col items-start">
+                <label for="gradient-end" class="font-medium text-gray-700 mb-1">Background Gradient End</label>
+                <input id="gradient-end" type="color" value="#6ee7b7" class="w-full h-10" />
+            </div>
+            <div class="flex flex-col items-start">
+                <label for="card-color" class="font-medium text-gray-700 mb-1">Card Background Color</label>
+                <input id="card-color" type="color" value="#ffffff" class="w-full h-10" />
+            </div>
+            <div class="flex flex-col items-start">
+                <label for="card-text-color" class="font-medium text-gray-700 mb-1">Card Text Color</label>
+                <input id="card-text-color" type="color" value="#111827" class="w-full h-10" />
+            </div>
+            <div class="flex flex-col items-start">
+                <label for="card-image" class="font-medium text-gray-700 mb-1">Card Background Image (optional)</label>
+                <div class="flex items-center space-x-2 w-full">
+                    <input id="card-image" type="file" accept="image/*" class="flex-grow" />
+                    <button id="remove-card-image" type="button" class="px-3 py-2 bg-red-500 text-white rounded-md hover:bg-red-600 focus:outline-none focus:ring-2 focus:ring-red-400">Remove</button>
+                </div>
             </div>
 
             <!-- Links Wrapper (each link row is added via JS) -->
@@ -281,7 +309,7 @@
     <!-- K) LINKTREE OUTPUT SCREEN (Profile + Links + Back / Download)                -->
     <!-- ─────────────────────────────────────────────────────────────────────────────── -->
     <div id="linktree-screen" class="hidden flex-col items-center justify-center min-h-screen px-4">
-        <div class="bg-white rounded-xl shadow-lg p-8 w-full max-w-md space-y-6">
+        <div id="output-card" class="bg-white rounded-xl shadow-lg p-8 w-full max-w-md space-y-6">
             <div class="flex flex-col items-center space-y-4">
                 <img id="output-profile-pic" src="" alt="Profile Picture"
                     class="w-24 h-24 rounded-full object-cover hidden" />
@@ -307,6 +335,7 @@
     <!-- L) APP.JS (All the logic—auth, Firestore, UI flow, etc.)                      -->
     <!--────────────────────────────────────────────────────────────────────────────────-->
     <script type="module" src="app.js"></script>
+    <div id="version" class="fixed bottom-2 right-2 text-xs text-gray-500">v16</div>
 </body>
 
 </html>

--- a/public/style.css
+++ b/public/style.css
@@ -92,3 +92,18 @@
         font-size: 1.1rem;
     }
 }
+
+/* Builder card scrolling on small screens */
+#form-screen .card-wrapper {
+    max-height: 90vh;
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
+}
+
+/* Ensure page scrolls on mobile when form is taller than viewport */
+@media (max-width: 768px) {
+    html,
+    body {
+        overflow: auto;
+    }
+}


### PR DESCRIPTION
## Summary
- bump version to v17
- set initial welcome text styles then trigger transition for smooth size change
- transition text font-size and color with CSS

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6840c2ebd9888320a6daa4e55bdd6681