### PR TITLE
Improve security headers and autocomplete

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -6,6 +6,17 @@
       "**/.*",
       "**/node_modules/**"
     ],
+    "headers": [
+      {
+        "source": "**/*.@(js|css|html|png|jpg|jpeg|svg|ico)",
+        "headers": [
+          {
+            "key": "Cache-Control",
+            "value": "public, max-age=31536000, immutable"
+          }
+        ]
+      }
+    ],
     "rewrites": [
       {
         "source": "**",

--- a/public/app.js
+++ b/public/app.js
@@ -782,6 +782,7 @@ function addLinkRow(prefill = null) {
     labelInput.type = "text";
     labelInput.placeholder = "Label (e.g. Website)";
     labelInput.required = true;
+    labelInput.autocomplete = "off";
     labelInput.setAttribute("aria-describedby", `error-url-${rowIndex}`);
     labelInput.className =
         "w-full px-3 py-2 rounded-md bg-gray-700 text-gray-100 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-emerald-400 border border-transparent focus:border-emerald-400 transition";
@@ -819,6 +820,7 @@ function addLinkRow(prefill = null) {
     urlInput.type = "url";
     urlInput.placeholder = "https://example.com";
     urlInput.required = true;
+    urlInput.autocomplete = "off";
     urlInput.setAttribute("aria-describedby", `error-url-${rowIndex}`);
     urlInput.className =
         "w-full px-3 py-2 rounded-md bg-gray-700 text-gray-100 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-emerald-400 border border-transparent focus:border-emerald-400 transition";

--- a/public/index.html
+++ b/public/index.html
@@ -4,11 +4,25 @@
 
 <head>
     <meta charset="UTF-8" />
+    <link rel="icon" type="image/x-icon" href="/favicon.ico" />
+    <meta http-equiv="Content-Security-Policy"
+          content="default-src 'self'; script-src 'self' https://www.gstatic.com https://cdn.tailwindcss.com https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com; img-src 'self' data: https://*.firebaseapp.com; connect-src 'self' https://*.firebaseio.com https://*.gstatic.com; frame-ancestors 'none'; base-uri 'self';" />
+    <style>
+      html, :host {
+        -webkit-text-size-adjust: 100%;
+      }
+    </style>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Linker – Build Your Linktree</title>
 
     <!-- Tailwind CSS (CDN for quick dev; in production you’d extract this via PostCSS) -->
+
     <script src="https://cdn.tailwindcss.com"></script>
+    <!--
+      WARNING: “cdn.tailwindcss.com” is for development only.
+      In production, install Tailwind via npm/PostCSS or Tailwind CLI.
+      See: https://tailwindcss.com/docs/installation
+    -->
 
     <!-- Font Awesome (for the link icons, trash, arrows, etc.) -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css"
@@ -100,9 +114,9 @@
         <div class="bg-white rounded-xl shadow-lg p-8 w-full max-w-md">
             <h2 class="text-2xl font-semibold text-gray-900 mb-4">Admin Login</h2>
             <p id="admin-error" class="text-red-500 text-sm hidden mb-2" role="alert"></p>
-            <input id="admin-email" type="email" placeholder="admin@linkerapp.com"
+            <input id="admin-email" type="email" placeholder="admin@linkerapp.com" autocomplete="username"
                 class="w-full px-4 py-2 rounded-md border border-gray-300 mb-4 focus:outline-none focus:ring-2 focus:ring-gray-400" />
-            <input id="admin-password" type="password" placeholder="Password"
+            <input id="admin-password" type="password" placeholder="Password" autocomplete="current-password"
                 class="w-full px-4 py-2 rounded-md border border-gray-300 mb-6 focus:outline-none focus:ring-2 focus:ring-gray-400" />
             <button id="admin-login-submit"
                 class="w-full py-3 bg-gray-900 text-white rounded-lg hover:bg-gray-800 transition focus:outline-none focus:ring-2 focus:ring-gray-700 mb-4">
@@ -124,7 +138,7 @@
 
             <!-- Create Access Code -->
             <div class="space-y-2">
-                <input id="new-access-code" type="text" placeholder="Enter new access code"
+                <input id="new-access-code" type="text" placeholder="Enter new access code" autocomplete="off"
                     class="w-full px-4 py-2 rounded-md border border-gray-300 focus:outline-none focus:ring-2 focus:ring-emerald-400" />
                 <button id="create-code-btn"
                     class="w-full py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600 transition focus:outline-none focus:ring-2 focus:ring-blue-400">
@@ -156,9 +170,9 @@
         <div class="bg-white rounded-xl shadow-lg p-8 w-full max-w-md">
             <h2 class="text-2xl font-semibold text-gray-900 mb-4">User Login</h2>
             <p id="user-error" class="text-red-500 text-sm hidden mb-2" role="alert"></p>
-            <input id="user-email" type="email" placeholder="you@example.com"
+            <input id="user-email" type="email" placeholder="you@example.com" autocomplete="username"
                 class="w-full px-4 py-2 rounded-md border border-gray-300 mb-4 focus:outline-none focus:ring-2 focus:ring-emerald-400" />
-            <input id="user-password" type="password" placeholder="Password"
+            <input id="user-password" type="password" placeholder="Password" autocomplete="current-password"
                 class="w-full px-4 py-2 rounded-md border border-gray-300 mb-6 focus:outline-none focus:ring-2 focus:ring-emerald-400" />
             <button id="user-login-submit"
                 class="w-full py-3 bg-green-500 text-white rounded-lg hover:bg-green-600 transition focus:outline-none focus:ring-2 focus:ring-green-400 mb-4">
@@ -179,11 +193,11 @@
         <div class="bg-white rounded-xl shadow-lg p-8 w-full max-w-md space-y-4">
             <h2 class="text-2xl font-semibold text-gray-900">Sign Up with Access Code</h2>
             <p id="signup-code-error" class="text-red-500 text-sm hidden" role="alert"></p>
-            <input id="signup-code" type="text" placeholder="Enter access code"
+            <input id="signup-code" type="text" placeholder="Enter access code" autocomplete="off"
                 class="w-full px-4 py-2 rounded-md border border-gray-300 focus:outline-none focus:ring-2 focus:ring-blue-400" />
-            <input id="signup-email" type="email" placeholder="you@example.com"
+            <input id="signup-email" type="email" placeholder="you@example.com" autocomplete="email"
                 class="w-full px-4 py-2 rounded-md border border-gray-300 focus:outline-none focus:ring-2 focus:ring-emerald-400" />
-            <input id="signup-password" type="password" placeholder="Choose a password"
+            <input id="signup-password" type="password" placeholder="Choose a password" autocomplete="new-password"
                 class="w-full px-4 py-2 rounded-md border border-gray-300 focus:outline-none focus:ring-2 focus:ring-emerald-400" />
             <button id="signup-submit"
                 class="w-full py-3 bg-blue-500 text-white rounded-lg hover:bg-blue-600 transition focus:outline-none focus:ring-2 focus:ring-blue-400">
@@ -224,7 +238,7 @@
             <!-- Profile Picture -->
             <div class="flex flex-col items-start">
                 <label for="profile-pic-file" class="font-medium text-gray-700 mb-1">Profile Picture</label>
-                <input id="profile-pic-file" type="file" accept="image/*"
+                <input id="profile-pic-file" type="file" accept="image/*" autocomplete="off"
                     class="w-full block text-sm text-gray-700 bg-white border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-emerald-400" />
                 <p id="error-profile-pic" class="text-red-500 text-sm hidden mt-1">Please upload a valid image.</p>
             </div>
@@ -232,7 +246,7 @@
             <!-- Username (Handle) -->
             <div class="flex flex-col items-start">
                 <label for="username" class="font-medium text-gray-700 mb-1">Username (handle)</label>
-                <input id="username" type="text" placeholder="@yourhandle"
+                <input id="username" type="text" placeholder="@yourhandle" autocomplete="username"
                     class="w-full px-4 py-2 rounded-md border border-gray-300 focus:outline-none focus:ring-2 focus:ring-emerald-400" />
                 <p id="error-username" class="text-red-500 text-sm hidden mt-1">Please enter a valid handle (e.g.
                     @john_doe).</p>
@@ -241,7 +255,7 @@
             <!-- Tagline (optional) -->
             <div class="flex flex-col items-start">
                 <label for="tagline" class="font-medium text-gray-700 mb-1">Tagline (optional)</label>
-                <textarea id="tagline" rows="2" placeholder="Tell people what you do (max 100 chars)" maxlength="100"
+                <textarea id="tagline" rows="2" placeholder="Tell people what you do (max 100 chars)" maxlength="100" autocomplete="off"
                     class="w-full px-4 py-2 rounded-md border border-gray-300 focus:outline-none focus:ring-2 focus:ring-emerald-400"></textarea>
                 <p id="tagline-count" class="text-gray-600 text-sm">0/100</p>
             </div>
@@ -249,24 +263,24 @@
             <!-- Theme Customization -->
             <div class="flex flex-col items-start">
                 <label for="gradient-start" class="font-medium text-gray-700 mb-1">Background Gradient Start</label>
-                <input id="gradient-start" type="color" value="#a7f3d0" class="w-full h-10" />
+                <input id="gradient-start" type="color" value="#a7f3d0" autocomplete="off" class="w-full h-10" />
             </div>
             <div class="flex flex-col items-start">
                 <label for="gradient-end" class="font-medium text-gray-700 mb-1">Background Gradient End</label>
-                <input id="gradient-end" type="color" value="#6ee7b7" class="w-full h-10" />
+                <input id="gradient-end" type="color" value="#6ee7b7" autocomplete="off" class="w-full h-10" />
             </div>
             <div class="flex flex-col items-start">
                 <label for="card-color" class="font-medium text-gray-700 mb-1">Card Background Color</label>
-                <input id="card-color" type="color" value="#ffffff" class="w-full h-10" />
+                <input id="card-color" type="color" value="#ffffff" autocomplete="off" class="w-full h-10" />
             </div>
             <div class="flex flex-col items-start">
                 <label for="card-text-color" class="font-medium text-gray-700 mb-1">Card Text Color</label>
-                <input id="card-text-color" type="color" value="#111827" class="w-full h-10" />
+                <input id="card-text-color" type="color" value="#111827" autocomplete="off" class="w-full h-10" />
             </div>
             <div class="flex flex-col items-start">
                 <label for="card-image" class="font-medium text-gray-700 mb-1">Card Background Image (optional)</label>
                 <div class="flex items-center space-x-2 w-full">
-                    <input id="card-image" type="file" accept="image/*" class="flex-grow" />
+                    <input id="card-image" type="file" accept="image/*" autocomplete="off" class="flex-grow" />
                     <button id="remove-card-image" type="button"
                         class="px-3 py-2 bg-red-500 text-white rounded-md hover:bg-red-600 focus:outline-none focus:ring-2 focus:ring-red-400">
                         Remove


### PR DESCRIPTION
## Summary
- secure the `<head>` with Content Security Policy meta tag
- add favicon link with explicit MIME type
- document Tailwind CDN usage and fix text-size adjust warning
- specify autocomplete values for all input fields
- disable autocomplete for link inputs created in JS
- cache static assets using Firebase Hosting headers

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68432a8a7e948320bf4be1cdb29af6d1