### PR TITLE
Improve UI/UX and add PWA support

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -272,6 +272,7 @@ const outputTagline = document.getElementById("output-tagline");
 const linksContainer = document.getElementById("links-container");
 const backBtn = document.getElementById("back-btn");
 const downloadBtn = document.getElementById("download-btn");
+const toggle = document.getElementById("theme-toggle");
 
 
 // ───────────────────────────────────────────────────────────────────────────────
@@ -653,10 +654,9 @@ async function startAppFlow(currentEmail) {
     welcomeScreen.classList.remove("hidden");
     welcomeScreen.classList.add("flex");
 
-    const isAdmin = currentEmail.toLowerCase() === ADMIN_EMAIL.toLowerCase();
-    welcomeText.textContent = isAdmin
-        ? `Thank you for logging in, Admin. Let’s build your Linktree next!`
-        : `Thank you for logging in, ${currentEmail}! Let’s build your Linktree!`;
+    const h = new Date().getHours();
+    const greet = h < 12 ? "Good morning" : h < 18 ? "Good afternoon" : "Good evening";
+    welcomeText.textContent = `${greet}, ${currentEmail}! Ready to Link?`;
 
     // Fade banner in/out:
     welcomeText.classList.remove("opacity-0");    // show it
@@ -1136,6 +1136,8 @@ function renderOutput(data) {
         }
     });
 
+    outputCard.classList.add("animate-fadeInUp");
+
     hideAllScreens();
     linktreeScreen.classList.remove("hidden");
     linktreeScreen.classList.add("flex");
@@ -1271,3 +1273,26 @@ resetBtn.addEventListener("click", async () => {
     }
     location.reload();
 });
+
+if (toggle) {
+    toggle.addEventListener("click", () => {
+        const t = document.documentElement.getAttribute("data-theme") === "dark" ? "light" : "dark";
+        document.documentElement.setAttribute("data-theme", t);
+        localStorage.setItem("theme", t);
+    });
+}
+document.documentElement.setAttribute("data-theme", localStorage.getItem("theme") || "light");
+
+window.addEventListener("keydown", (e) => {
+    if ((e.ctrlKey || e.metaKey) && e.key === "s") {
+        e.preventDefault();
+        generateBtn.click();
+    }
+    if (e.key === "Escape") {
+        document.querySelectorAll('[role="alert"]').forEach((el) => el.classList.add("hidden"));
+    }
+});
+
+if ("serviceWorker" in navigator) {
+    navigator.serviceWorker.register("/service-worker.js");
+}

--- a/public/index.html
+++ b/public/index.html
@@ -8,6 +8,16 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Linker – Build Your Linktree</title>
 
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap" rel="stylesheet">
+    <style>body { font-family: 'Inter', sans-serif; }</style>
+
+    <meta name="theme-color" content="#10b981">
+    <link rel="manifest" href="/manifest.json">
+    <meta name="description" content="Build your own premium Linktree-style page instantly.">
+    <meta property="og:title" content="Linker – Your Custom Linktree">
+    <meta property="og:description" content="Create a beautiful link page in seconds.">
+    <meta property="og:image" content="/social-share.png">
+
     <!-- Tailwind CSS (CDN for quick dev; in production you’d extract this via PostCSS) -->
     <script src="https://cdn.tailwindcss.com"></script>
     <!--
@@ -72,13 +82,20 @@
     <!-- A) STARTUP OVERLAY (black → fade to transparent + slide‐up text)             -->
     <!-- ─────────────────────────────────────────────────────────────────────────────── -->
     <div id="startup-screen">
-        <div id="startup-text">Welcome to Linker</div>
+        <h1 id="startup-text"
+            class="text-4xl font-extrabold tracking-tight bg-gradient-to-r from-emerald-400 to-green-500 bg-clip-text text-transparent">
+            Welcome to Linker
+        </h1>
     </div>
 
     <!-- ─────────────────────────────────────────────────────────────────────────────── -->
     <!-- C) LOGIN SCREEN (Landing Page with three big buttons)                        -->
     <!-- ─────────────────────────────────────────────────────────────────────────────── -->
     <div id="login-screen" class="hidden flex-col items-center justify-center min-h-screen text-center space-y-6 px-4">
+        <header class="flex justify-between items-center p-4">
+            <img src="/logo.svg" alt="Linker" class="h-8 w-auto">
+            <button id="theme-toggle" class="p-2 focus:ring-2 focus:ring-offset-2 focus:ring-emerald-500">🌓</button>
+        </header>
         <div class="bg-white rounded-xl shadow-lg p-8 w-full max-w-md">
             <h1 class="text-2xl font-semibold text-gray-900 mb-6">Welcome to Linker</h1>
             <button id="btn-admin-login"
@@ -101,6 +118,10 @@
     <!-- ─────────────────────────────────────────────────────────────────────────────── -->
     <div id="admin-login-screen"
         class="hidden flex-col items-center justify-center min-h-screen text-center space-y-4 px-4">
+        <header class="flex justify-between items-center p-4">
+            <img src="/logo.svg" alt="Linker" class="h-8 w-auto">
+            <button id="theme-toggle" class="p-2 focus:ring-2 focus:ring-offset-2 focus:ring-emerald-500">🌓</button>
+        </header>
         <div class="bg-white rounded-xl shadow-lg p-8 w-full max-w-md">
             <h2 class="text-2xl font-semibold text-gray-900 mb-4">Admin Login</h2>
             <p id="admin-error" class="text-red-500 text-sm hidden mb-2" role="alert"></p>
@@ -122,6 +143,10 @@
     <!-- E) ADMIN PANEL (Create Codes / Build Form / Logout)                           -->
     <!-- ─────────────────────────────────────────────────────────────────────────────── -->
     <div id="admin-panel" class="hidden flex-col items-center justify-center min-h-screen space-y-6 px-4">
+        <header class="flex justify-between items-center p-4">
+            <img src="/logo.svg" alt="Linker" class="h-8 w-auto">
+            <button id="theme-toggle" class="p-2 focus:ring-2 focus:ring-offset-2 focus:ring-emerald-500">🌓</button>
+        </header>
         <div class="bg-white rounded-xl shadow-lg p-8 w-full max-w-md space-y-6">
             <h2 class="text-2xl font-semibold text-gray-900">Admin Panel</h2>
 
@@ -155,6 +180,10 @@
     <!-- ─────────────────────────────────────────────────────────────────────────────── -->
     <div id="user-login-screen"
         class="hidden flex-col items-center justify-center min-h-screen text-center space-y-4 px-4">
+        <header class="flex justify-between items-center p-4">
+            <img src="/logo.svg" alt="Linker" class="h-8 w-auto">
+            <button id="theme-toggle" class="p-2 focus:ring-2 focus:ring-offset-2 focus:ring-emerald-500">🌓</button>
+        </header>
         <div class="bg-white rounded-xl shadow-lg p-8 w-full max-w-md">
             <h2 class="text-2xl font-semibold text-gray-900 mb-4">User Login</h2>
             <p id="user-error" class="text-red-500 text-sm hidden mb-2" role="alert"></p>
@@ -177,6 +206,10 @@
     <!-- ─────────────────────────────────────────────────────────────────────────────── -->
     <div id="user-signup-screen"
         class="hidden flex-col items-center justify-center min-h-screen text-center space-y-4 px-4">
+        <header class="flex justify-between items-center p-4">
+            <img src="/logo.svg" alt="Linker" class="h-8 w-auto">
+            <button id="theme-toggle" class="p-2 focus:ring-2 focus:ring-offset-2 focus:ring-emerald-500">🌓</button>
+        </header>
         <div class="bg-white rounded-xl shadow-lg p-8 w-full max-w-md space-y-4">
             <h2 class="text-2xl font-semibold text-gray-900">Sign Up with Access Code</h2>
             <p id="signup-code-error" class="text-red-500 text-sm hidden" role="alert"></p>
@@ -210,11 +243,16 @@
     <!-- ─────────────────────────────────────────────────────────────────────────────── -->
     <!-- I) BUILDER FORM SCREEN (Upload Picture / Handle / Tagline / Links)            -->
     <!-- ─────────────────────────────────────────────────────────────────────────────── -->
-    <div id="form-screen"
+<div id="form-screen"
         class="hidden flex items-center justify-center min-h-screen pt-6 px-4 bg-gradient-to-br from-green-200 to-green-300 overflow-y-auto">
+        <header class="flex justify-between items-center p-4">
+            <img src="/logo.svg" alt="Linker" class="h-8 w-auto">
+            <button id="theme-toggle" class="p-2 focus:ring-2 focus:ring-offset-2 focus:ring-emerald-500">🌓</button>
+        </header>
         <div
-            class="card-wrapper w-full max-w-md bg-white rounded-2xl shadow-lg p-6 space-y-6 max-h-[90vh] overflow-y-auto">
+            class="card-wrapper w-full max-w-md bg-white rounded-2xl shadow-lg p-6 space-y-6 max-h-[90vh] overflow-y-auto animate-fadeInUp">
             <button id="reset-btn" type="button" class="hidden btn-reset self-start mb-4">Reset</button>
+            <div id="skeleton-wrapper" class="space-y-6 animate-pulse">
             <h2 class="text-2xl font-semibold text-gray-900">Build Your Linktree</h2>
             <p class="text-gray-800">
                 Upload a profile picture, add your handle, tagline, and links below.
@@ -284,6 +322,10 @@
                 At least one valid link is required.
             </p>
 
+            </div>
+
+            <hr class="my-6 border-t border-gray-200" />
+
             <!-- Generate Button -->
             <button id="generate-btn" class="w-full py-3 bg-gray-600 text-gray-300 rounded-lg cursor-not-allowed"
                 disabled>
@@ -296,6 +338,10 @@
     <!-- J) LOADER SCREEN (Spinning Icon)                                             -->
     <!-- ─────────────────────────────────────────────────────────────────────────────── -->
     <div id="loader-screen" class="hidden flex-col items-center justify-center min-h-screen bg-gray-900 bg-opacity-50">
+        <header class="flex justify-between items-center p-4">
+            <img src="/logo.svg" alt="Linker" class="h-8 w-auto">
+            <button id="theme-toggle" class="p-2 focus:ring-2 focus:ring-offset-2 focus:ring-emerald-500">🌓</button>
+        </header>
         <div class="animate-spin rounded-full h-16 w-16 border-t-4 border-green-400"></div>
     </div>
 
@@ -303,7 +349,11 @@
     <!-- K) LINKTREE OUTPUT SCREEN (Profile + Links + Back / Download)                -->
     <!-- ─────────────────────────────────────────────────────────────────────────────── -->
     <div id="linktree-screen" class="hidden flex-col items-center justify-center min-h-screen px-4">
-        <div id="output-card" class="bg-white rounded-xl shadow-lg p-8 w-full max-w-md space-y-6">
+        <header class="flex justify-between items-center p-4">
+            <img src="/logo.svg" alt="Linker" class="h-8 w-auto">
+            <button id="theme-toggle" class="p-2 focus:ring-2 focus:ring-offset-2 focus:ring-emerald-500">🌓</button>
+        </header>
+        <div id="output-card" class="bg-white rounded-xl shadow-lg p-8 w-full max-w-md space-y-6 animate-fadeInUp">
             <div class="flex flex-col items-center space-y-4">
                 <img id="output-profile-pic" src="" alt="Profile Picture"
                     class="w-24 h-24 rounded-full object-cover hidden" />

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,9 @@
+{
+  "name": "Linker",
+  "short_name": "Linker",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#10b981",
+  "icons": [{"src":"icon-192.png","sizes":"192x192","type":"image/png"}]
+}

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,0 +1,3 @@
+const CACHE = 'linker-v1', ASSETS = ['/', '/index.html', '/style.css', '/app.js'];
+self.addEventListener('install', e=>e.waitUntil(caches.open(CACHE).then(c=>c.addAll(ASSETS))));
+self.addEventListener('fetch', e=>e.respondWith(caches.match(e.request).then(r=>r||fetch(e.request))));

--- a/public/style.css
+++ b/public/style.css
@@ -1,5 +1,28 @@
 /* style.css */
 
+@keyframes fadeInUp {
+  from { opacity: 0; transform: translateY(12px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+.animate-fadeInUp {
+  animation: fadeInUp 0.6s ease-out both;
+}
+
+:root[data-theme="light"] {
+  --bg: #ffffff;
+  --fg: #111827;
+  --accent: #10b981;
+}
+:root[data-theme="dark"] {
+  --bg: #1f2937;
+  --fg: #f9fafb;
+  --accent: #059669;
+}
+body {
+  background: var(--bg);
+  color: var(--fg);
+}
+
 /* ──────────────────────────────────────────────────────────────────────────── */
 /* A) STARTUP FADE KEYFRAMES (1.5 s total)                                      */
 /* ──────────────────────────────────────────────────────────────────────────── */
@@ -175,3 +198,19 @@
         overflow: auto;
     }
 }
+
+.card-wrapper,
+.output-card {
+    border: 1px solid #e5e7eb;
+    box-shadow: 0 10px 25px rgba(0,0,0,0.1);
+    transition: all 0.3s ease-in-out;
+}
+
+.link-btn {
+    transform: translateZ(0);
+    transition: transform 0.2s ease-in-out;
+}
+.link-btn:hover {
+    transform: scale(1.05);
+}
+


### PR DESCRIPTION
## Summary
- polish cards with depth, hover transitions and fade-in animation
- introduce light/dark CSS variables and Inter font
- embed header with theme toggle and upgrade startup text
- add skeleton wrapper and divider in builder
- integrate keyboard shortcuts, dynamic greeting and theme toggle logic
- register service worker and include manifest

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684c5878a0cc83209048cd585144f939