### PR TITLE
Enhance UI theme and logo references

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1136,6 +1136,7 @@ function renderOutput(data) {
         }
     });
 
+    outputCard.classList.remove("animate-pulse");
     outputCard.classList.add("animate-fadeInUp");
 
     hideAllScreens();

--- a/public/index.html
+++ b/public/index.html
@@ -83,7 +83,7 @@
     <!-- ─────────────────────────────────────────────────────────────────────────────── -->
     <div id="startup-screen">
         <h1 id="startup-text"
-            class="text-4xl font-extrabold tracking-tight bg-gradient-to-r from-emerald-400 to-green-500 bg-clip-text text-transparent">
+        class="text-4xl font-extrabold tracking-tight bg-gradient-to-r from-accent to-accent-dark bg-clip-text text-transparent">
             Welcome to Linker
         </h1>
     </div>
@@ -93,8 +93,8 @@
     <!-- ─────────────────────────────────────────────────────────────────────────────── -->
     <div id="login-screen" class="hidden flex-col items-center justify-center min-h-screen text-center space-y-6 px-4">
         <header class="flex justify-between items-center p-4">
-            <img src="/logo.svg" alt="Linker" class="h-8 w-auto">
-            <button id="theme-toggle" class="p-2 focus:ring-2 focus:ring-offset-2 focus:ring-emerald-500">🌓</button>
+            <img src="/images/73294b6e-8bc4-428f-ad24-a303947fb853.png" alt="Linker Logo" class="h-8 w-auto">
+            <button id="theme-toggle" class="p-2 focus:ring-2 focus:ring-offset-2 focus:ring-accent">🌓</button>
         </header>
         <div class="bg-white rounded-xl shadow-lg p-8 w-full max-w-md">
             <h1 class="text-2xl font-semibold text-gray-900 mb-6">Welcome to Linker</h1>
@@ -119,8 +119,8 @@
     <div id="admin-login-screen"
         class="hidden flex-col items-center justify-center min-h-screen text-center space-y-4 px-4">
         <header class="flex justify-between items-center p-4">
-            <img src="/logo.svg" alt="Linker" class="h-8 w-auto">
-            <button id="theme-toggle" class="p-2 focus:ring-2 focus:ring-offset-2 focus:ring-emerald-500">🌓</button>
+            <img src="/images/73294b6e-8bc4-428f-ad24-a303947fb853.png" alt="Linker Logo" class="h-8 w-auto">
+            <button id="theme-toggle" class="p-2 focus:ring-2 focus:ring-offset-2 focus:ring-accent">🌓</button>
         </header>
         <div class="bg-white rounded-xl shadow-lg p-8 w-full max-w-md">
             <h2 class="text-2xl font-semibold text-gray-900 mb-4">Admin Login</h2>
@@ -144,8 +144,8 @@
     <!-- ─────────────────────────────────────────────────────────────────────────────── -->
     <div id="admin-panel" class="hidden flex-col items-center justify-center min-h-screen space-y-6 px-4">
         <header class="flex justify-between items-center p-4">
-            <img src="/logo.svg" alt="Linker" class="h-8 w-auto">
-            <button id="theme-toggle" class="p-2 focus:ring-2 focus:ring-offset-2 focus:ring-emerald-500">🌓</button>
+            <img src="/images/73294b6e-8bc4-428f-ad24-a303947fb853.png" alt="Linker Logo" class="h-8 w-auto">
+            <button id="theme-toggle" class="p-2 focus:ring-2 focus:ring-offset-2 focus:ring-accent">🌓</button>
         </header>
         <div class="bg-white rounded-xl shadow-lg p-8 w-full max-w-md space-y-6">
             <h2 class="text-2xl font-semibold text-gray-900">Admin Panel</h2>
@@ -181,8 +181,8 @@
     <div id="user-login-screen"
         class="hidden flex-col items-center justify-center min-h-screen text-center space-y-4 px-4">
         <header class="flex justify-between items-center p-4">
-            <img src="/logo.svg" alt="Linker" class="h-8 w-auto">
-            <button id="theme-toggle" class="p-2 focus:ring-2 focus:ring-offset-2 focus:ring-emerald-500">🌓</button>
+            <img src="/images/73294b6e-8bc4-428f-ad24-a303947fb853.png" alt="Linker Logo" class="h-8 w-auto">
+            <button id="theme-toggle" class="p-2 focus:ring-2 focus:ring-offset-2 focus:ring-accent">🌓</button>
         </header>
         <div class="bg-white rounded-xl shadow-lg p-8 w-full max-w-md">
             <h2 class="text-2xl font-semibold text-gray-900 mb-4">User Login</h2>
@@ -207,8 +207,8 @@
     <div id="user-signup-screen"
         class="hidden flex-col items-center justify-center min-h-screen text-center space-y-4 px-4">
         <header class="flex justify-between items-center p-4">
-            <img src="/logo.svg" alt="Linker" class="h-8 w-auto">
-            <button id="theme-toggle" class="p-2 focus:ring-2 focus:ring-offset-2 focus:ring-emerald-500">🌓</button>
+            <img src="/images/73294b6e-8bc4-428f-ad24-a303947fb853.png" alt="Linker Logo" class="h-8 w-auto">
+            <button id="theme-toggle" class="p-2 focus:ring-2 focus:ring-offset-2 focus:ring-accent">🌓</button>
         </header>
         <div class="bg-white rounded-xl shadow-lg p-8 w-full max-w-md space-y-4">
             <h2 class="text-2xl font-semibold text-gray-900">Sign Up with Access Code</h2>
@@ -246,8 +246,8 @@
 <div id="form-screen"
         class="hidden flex items-center justify-center min-h-screen pt-6 px-4 bg-gradient-to-br from-green-200 to-green-300 overflow-y-auto">
         <header class="flex justify-between items-center p-4">
-            <img src="/logo.svg" alt="Linker" class="h-8 w-auto">
-            <button id="theme-toggle" class="p-2 focus:ring-2 focus:ring-offset-2 focus:ring-emerald-500">🌓</button>
+            <img src="/images/73294b6e-8bc4-428f-ad24-a303947fb853.png" alt="Linker Logo" class="h-8 w-auto">
+            <button id="theme-toggle" class="p-2 focus:ring-2 focus:ring-offset-2 focus:ring-accent">🌓</button>
         </header>
         <div
             class="card-wrapper w-full max-w-md bg-white rounded-2xl shadow-lg p-6 space-y-6 max-h-[90vh] overflow-y-auto animate-fadeInUp">
@@ -324,7 +324,7 @@
 
             </div>
 
-            <hr class="my-6 border-t border-gray-200" />
+            <hr class="my-6 border-t border-gray-300" />
 
             <!-- Generate Button -->
             <button id="generate-btn" class="w-full py-3 bg-gray-600 text-gray-300 rounded-lg cursor-not-allowed"
@@ -339,8 +339,8 @@
     <!-- ─────────────────────────────────────────────────────────────────────────────── -->
     <div id="loader-screen" class="hidden flex-col items-center justify-center min-h-screen bg-gray-900 bg-opacity-50">
         <header class="flex justify-between items-center p-4">
-            <img src="/logo.svg" alt="Linker" class="h-8 w-auto">
-            <button id="theme-toggle" class="p-2 focus:ring-2 focus:ring-offset-2 focus:ring-emerald-500">🌓</button>
+            <img src="/images/73294b6e-8bc4-428f-ad24-a303947fb853.png" alt="Linker Logo" class="h-8 w-auto">
+            <button id="theme-toggle" class="p-2 focus:ring-2 focus:ring-offset-2 focus:ring-accent">🌓</button>
         </header>
         <div class="animate-spin rounded-full h-16 w-16 border-t-4 border-green-400"></div>
     </div>
@@ -350,8 +350,8 @@
     <!-- ─────────────────────────────────────────────────────────────────────────────── -->
     <div id="linktree-screen" class="hidden flex-col items-center justify-center min-h-screen px-4">
         <header class="flex justify-between items-center p-4">
-            <img src="/logo.svg" alt="Linker" class="h-8 w-auto">
-            <button id="theme-toggle" class="p-2 focus:ring-2 focus:ring-offset-2 focus:ring-emerald-500">🌓</button>
+            <img src="/images/73294b6e-8bc4-428f-ad24-a303947fb853.png" alt="Linker Logo" class="h-8 w-auto">
+            <button id="theme-toggle" class="p-2 focus:ring-2 focus:ring-offset-2 focus:ring-accent">🌓</button>
         </header>
         <div id="output-card" class="bg-white rounded-xl shadow-lg p-8 w-full max-w-md space-y-6 animate-fadeInUp">
             <div class="flex flex-col items-center space-y-4">

--- a/public/style.css
+++ b/public/style.css
@@ -9,14 +9,16 @@
 }
 
 :root[data-theme="light"] {
-  --bg: #ffffff;
-  --fg: #111827;
-  --accent: #10b981;
+  --bg: #f0f0f0;
+  --fg: #1f1f1f;
+  --accent: #00d2ff;
+  --accent-dark: #0099cc;
 }
 :root[data-theme="dark"] {
-  --bg: #1f2937;
-  --fg: #f9fafb;
-  --accent: #059669;
+  --bg: #1f1f1f;
+  --fg: #e5e7eb;
+  --accent: #00d2ff;
+  --accent-dark: #0099cc;
 }
 body {
   background: var(--bg);
@@ -201,16 +203,25 @@ body {
 
 .card-wrapper,
 .output-card {
-    border: 1px solid #e5e7eb;
-    box-shadow: 0 10px 25px rgba(0,0,0,0.1);
+    border: 1px solid rgba(0,0,0,0.1);
+    box-shadow: 0 10px 25px rgba(0,0,0,0.15);
     transition: all 0.3s ease-in-out;
+    background: var(--bg);
+    color: var(--fg);
 }
 
 .link-btn {
-    transform: translateZ(0);
-    transition: transform 0.2s ease-in-out;
+  background-color: var(--accent);
+  color: #ffffff;
+  transition: background-color 0.2s ease, transform 0.2s ease;
+  transform: translateZ(0);
 }
 .link-btn:hover {
-    transform: scale(1.05);
+  background-color: var(--accent-dark);
+  transform: scale(1.05);
+}
+.link-btn:focus {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(0,210,255,0.5);
 }
 


### PR DESCRIPTION
## Summary
- new modern color scheme and accent variables
- update all headers with new logo reference
- animate output card with fade-in effect
- tweak builder separator styling

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684c606ed93483208472a4d80768fb2f