### PR TITLE
Use shared logo asset

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -6,7 +6,7 @@
 //  - splashFadeDuration: how long (in ms) the splash overlay fades out after grow.
 const CONFIG = {
   // Path to your header logo (absolute on your machine):
-  logoSrc: "C:\\Users\\reyno\\OneDrive\\Desktop\\Coding\\Linktree\\public\\image\\73294b6e-8bc4-428f-ad24-a303947fb853.png",
+  logoSrc: '/images/logo.png',
   // Splash
   splashLogoScale:        0.85,          // e.g. use 0.85 for 85% scale
   splashLogoMaxWidth:     '180px',       // constrain logo width

--- a/public/index.html
+++ b/public/index.html
@@ -38,7 +38,7 @@
   </button>
 
   <header>
-    <img src="\images\logo.png" 
+    <img src="/images/logo.png" 
          alt="Linker Logo" style="height: 2.5rem; width: auto;" />
     <button id="theme-toggle" aria-label="Toggle theme">🌗</button>
   </header>
@@ -49,7 +49,7 @@
     <!-- ─────────────────────────────────────────────────────────────────────────────── -->
     <div id="startup-screen">
       <img id="startup-logo"
-           src="\images\logo.png"
+           src="/images/logo.png"
            alt="Linker Logo" />
     </div>
 

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -16,6 +16,11 @@
       "src": "/linker-icon-512.png",
       "sizes": "512x512",
       "type": "image/png"
+    },
+    {
+      "src": "/images/logo.png",
+      "sizes": "512x512",
+      "type": "image/png"
     }
   ]
 }

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -2,7 +2,7 @@ const CACHE = 'linker-v2';
 const ASSETS = [
   '/', '/index.html', '/style.css', '/app.js',
   '/linker-icon-192.png', '/linker-icon-512.png', '/favicon.ico',
-  '/images/73294b6e-8bc4-428f-ad24-a303947fb853.png'
+  '/images/logo.png'
 ];
 self.addEventListener('install', e => e.waitUntil(
   caches.open(CACHE).then(c => c.addAll(ASSETS))


### PR DESCRIPTION
## Summary
- reference `/images/logo.png` consistently in the header and splash
- load the same logo path in `app.js`
- cache the logo in the service worker
- list `/images/logo.png` in `manifest.json`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684ec67dde7083209d6110091f822f4d