### PR TITLE
Improve frontend reliability with splash failsafe and toasts

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5,6 +5,8 @@
 <head>
     <meta charset="UTF-8" />
     <link rel="icon" href="/favicon.ico" />
+    <link rel="icon" sizes="192x192" href="/images/icon-192.png" />
+    <link rel="apple-touch-icon" href="/images/icon-192.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Linker – Build Your Linktree</title>
 
@@ -29,6 +31,7 @@
 </head>
 
 <body class="flex flex-col min-h-full">
+  <div id="toast-container" aria-live="polite"></div>
   <!-- hidden by default, we'll show it when needed -->
   <button
     id="reset-btn"
@@ -50,6 +53,7 @@
       <img id="startup-logo"
            src="/images/logo.png"
            alt="Linker Logo" />
+      <div id="loading-text" class="hidden">Loading…</div>
     </div>
 
     <!-- ─────────────────────────────────────────────────────────────────────────────── -->

--- a/public/style.css
+++ b/public/style.css
@@ -1,4 +1,5 @@
 /* === LINKER DESIGN SYSTEM VARIABLES ====================================== */
+/* === SURGERY: theme variables live here for quick tweaks ================== */
 /* All visual styles are controlled through the variables below. Tweak them  */
 /* to create entirely new themes without touching the rest of the CSS.       */
 
@@ -204,6 +205,7 @@ a:hover {
   background: var(--page-gradient);
   display: flex; align-items: center; justify-content: center;
   z-index: 100;
+  flex-direction: column;
 }
 #startup-logo {
   animation: logoGrow 1200ms ease-out forwards;
@@ -219,6 +221,11 @@ a:hover {
 }
 @keyframes fadeOut {
   to { opacity: 0; visibility: hidden; }
+}
+#loading-text {
+  margin-top: 1rem;
+  font-size: 1.1rem;
+  color: var(--fg);
 }
 /* ──────────────────────────────────────────────────────────────────────────── */
 /* B) UTILITY: hide vs. flex (JS toggles these)                                */
@@ -407,6 +414,35 @@ body::before {
 @keyframes moveGradient {
   from { background-position: 0% 50%; }
   to   { background-position: 100% 50%; }
+}
+
+/* === SURGERY: Toast styles ================================================ */
+#toast-container {
+  position: fixed;
+  top: 1rem;
+  right: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  z-index: 200;
+}
+.toast {
+  padding: 0.5rem 1rem;
+  border-radius: 0.5rem;
+  color: #fff;
+  font-weight: 600;
+  animation: fadeToast 4s forwards;
+}
+.toast-success { background: var(--success); }
+.toast-error { background: var(--error); }
+.toast-info { background: var(--info); }
+.toast-warning { background: var(--warning); }
+
+@keyframes fadeToast {
+  0% { opacity: 0; transform: translateY(-10px); }
+ 10% { opacity: 1; transform: translateY(0); }
+ 90% { opacity: 1; }
+100% { opacity: 0; transform: translateY(-10px); }
 }
 
 


### PR DESCRIPTION
## Summary
- add fallback icons
- include toast container and loading text in HTML
- tweak splash styling and add toast CSS
- implement stable splash logic with fail-safe
- show toast messages on login/signup events

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684eee5daec48320949df9cda8f5c041