### PR TITLE
Add dynamic island style header

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -38,13 +38,17 @@
     🔄 Reset
   </button>
 
-  <header role="banner" class="animate-fadeInUp">
-      <div class="flex items-center space-x-4">
-      <img src="/images/logo.png" alt="Linker Logo" />
-      <span class="text-xl font-semibold">Linker</span>
+  <div class="dynamic-header animate-fadeInUp" role="banner">
+    <div class="header-content">
+      <div class="header-left">
+        <img src="images/logo.png" alt="Linker Logo" class="header-logo" />
+        <span class="header-title">Linker</span>
+      </div>
+      <div class="header-right">
+        <button id="theme-toggle" class="theme-toggle-btn" aria-label="Toggle theme">🌗</button>
+      </div>
     </div>
-    <button id="theme-toggle" aria-label="Toggle theme">🌗</button>
-  </header>
+  </div>
 
 
     <!-- ─────────────────────────────────────────────────────────────────────────────── -->

--- a/public/style.css
+++ b/public/style.css
@@ -161,36 +161,46 @@ html, body {
   .screen { padding-top: 6rem; }
 }
 
-/* header at top */
-header {
+/* dynamic header "island" at top */
+.dynamic-header {
   position: fixed;
   top: 2.5rem;
   left: 50%;
   transform: translateX(-50%);
-  width: calc(100% - 2rem);
-  max-width: 560px;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
+  width: 85%;
+  max-width: 800px;
   padding: 1.25rem 1.75rem;
   background: var(--header-bg);
   border: 1px solid var(--header-border);
-  border-radius: 1.25rem;
+  border-radius: 1.75rem;
   backdrop-filter: blur(14px);
   box-shadow: var(--header-shadow);
-  gap: 1.25rem;
   z-index: 30;
 }
-@media (max-width: 640px) {
-  header {
-    top: 1.5rem;
-    padding: 1rem 1.25rem;
-    width: calc(100% - 1rem);
-  }
+
+.header-content {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
 }
-header img {
+
+.header-left {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.header-logo {
   height: var(--logo-size);
   width: auto;
+}
+
+@media (max-width: 640px) {
+  .dynamic-header {
+    top: 1.5rem;
+    width: calc(100% - 1rem);
+    padding: 1rem 1.25rem;
+  }
 }
 
 /* vertical stack for buttons inside any .screen */


### PR DESCRIPTION
## Summary
- restyle the header as a "dynamic island" floating bar
- restructure header markup to keep logo left and theme toggle right

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684f087ead3083209e61cb83b166281f