### PR TITLE
Improve layout spacing and header centering

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -649,9 +649,9 @@ function showBuilderForm(prefillData = null) {
     cardImageInput.value = "";
 
     // Hide errors
-    fadeOutElement(errorProfilePic, 0);
-    fadeOutElement(errorUsername, 0);
-    fadeOutElement(errorLinks, 0);
+    fadeOutElement(errorProfilePic);
+    fadeOutElement(errorUsername);
+    fadeOutElement(errorLinks);
 
     if (prefillData) {
         // Prefill picture (we’ll use data URL)
@@ -709,7 +709,7 @@ function showBuilderForm(prefillData = null) {
 function addLinkRow(prefill = null) {
     const rowIndex = linkRows.length;
     const rowDiv = document.createElement("div");
-    rowDiv.className = "space-y-1 bg-gray-800 p-4 rounded-lg";
+    rowDiv.className = "space-y-5 bg-gray-800 p-4 rounded-lg";
     rowDiv.setAttribute("draggable", "true");
 
     // 1) Label input
@@ -764,7 +764,7 @@ function addLinkRow(prefill = null) {
     // 4) Error text below URL
     const errorText = document.createElement("p");
     errorText.id = `error-url-${rowIndex}`;
-    errorText.className = "text-sm text-red-500 hidden";
+    errorText.className = "text-sm text-red-500 fade-message hidden";
     errorText.setAttribute("role", "alert");
     errorText.textContent = "Please enter a valid URL.";
 

--- a/public/index.html
+++ b/public/index.html
@@ -288,7 +288,7 @@
             </div>
 
             <!-- Links Wrapper (each link row is added via JS) -->
-            <div id="links-wrapper" class="space-y-4 bg-gray-800 p-4 rounded-lg"></div>
+            <div id="links-wrapper" class="space-y-6 bg-gray-800 p-4 rounded-lg"></div>
             <div class="form-group mt-6">
                 <button id="add-link-btn"
                     class="w-full py-3 bg-green-500 text-white rounded-lg hover:bg-green-600 transition focus:outline-none focus:ring-2 focus:ring-green-400">

--- a/public/style.css
+++ b/public/style.css
@@ -169,6 +169,8 @@ html, body {
   transform: translateX(-50%);
   width: 85%;
   max-width: 800px;
+  margin-left: auto;
+  margin-right: auto;
   padding: 1.25rem 1.75rem;
   background: var(--header-bg);
   border: 1px solid var(--header-border);
@@ -199,6 +201,8 @@ html, body {
   .dynamic-header {
     top: 1.5rem;
     width: calc(100% - 1rem);
+    margin-left: auto;
+    margin-right: auto;
     padding: 1rem 1.25rem;
   }
 }
@@ -321,7 +325,7 @@ a:hover {
         background-color: var(--card-bg);
         border: 1px solid var(--card-border);
         border-radius: 1.5rem;
-        padding: 2rem;
+        padding: 2.5rem;
         box-shadow: var(--card-shadow);
         width: 100%;
         max-width: 560px;
@@ -526,7 +530,7 @@ button:active {
 .form-group {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 1.5rem;
   width: 100%;
 }
 


### PR DESCRIPTION
## Summary
- keep dynamic header centered on all screens
- add consistent vertical spacing to forms
- expand builder card padding for better balance
- space out builder link rows and wrapper
- smooth fade animations for builder errors

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684f0b55269c83209b20107e7a9a1ae4